### PR TITLE
added level trigger to next scene + load improved

### DIFF
--- a/CapstoneProject/Assets/Scenes/Levels/Level1.unity
+++ b/CapstoneProject/Assets/Scenes/Levels/Level1.unity
@@ -483,7 +483,7 @@ TilemapRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 2033761727
-  m_SortingLayer: 2
+  m_SortingLayer: 3
   m_SortingOrder: 0
   m_ChunkSize: {x: 32, y: 32, z: 32}
   m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
@@ -43080,7 +43080,7 @@ TilemapRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 2033761727
-  m_SortingLayer: 2
+  m_SortingLayer: 3
   m_SortingOrder: 0
   m_ChunkSize: {x: 32, y: 32, z: 32}
   m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
@@ -44579,6 +44579,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e7563216b82b9824abb538d576d2875e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _coins: {fileID: 0}
+  _coinsInTheChest: 100
 --- !u!1 &850285785
 GameObject:
   m_ObjectHideFlags: 3
@@ -44845,7 +44847,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 761495559
-  m_SortingLayer: 6
+  m_SortingLayer: 7
   m_SortingOrder: 0
   m_Sprite: {fileID: -1149766077, guid: b5da5163583600b45ab7f14f4ab8bbef, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -45261,7 +45263,7 @@ TilemapRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 938394091
-  m_SortingLayer: 3
+  m_SortingLayer: 4
   m_SortingOrder: 0
   m_ChunkSize: {x: 32, y: 32, z: 32}
   m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
@@ -50347,7 +50349,7 @@ TilemapRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 938394091
-  m_SortingLayer: 3
+  m_SortingLayer: 4
   m_SortingOrder: 0
   m_ChunkSize: {x: 32, y: 32, z: 32}
   m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
@@ -52478,6 +52480,149 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 7153236286422711457, guid: 1dc4c1f211afafa4b80290c465aeb90d, type: 3}
   m_PrefabInstance: {fileID: 37426894}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2087785536
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2087785541}
+  - component: {fileID: 2087785540}
+  - component: {fileID: 2087785539}
+  - component: {fileID: 2087785537}
+  - component: {fileID: 2087785542}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2087785537
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2087785536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fd27b2d62bd461244be7c0b963406031, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nextScene: Assets/Scenes/Levels/Level2.unity
+--- !u!23 &2087785539
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2087785536}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &2087785540
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2087785536}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &2087785541
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2087785536}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 150, y: -90, z: 1.2823076}
+  m_LocalScale: {x: 6, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &2087785542
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2087785536}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!4 &2103221690 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3266952283701380807, guid: 20f0179edf7284941ba366116b1077cb, type: 3}
@@ -53186,3 +53331,4 @@ SceneRoots:
   - {fileID: 1185196911}
   - {fileID: 1845748251}
   - {fileID: 8061226409761331837}
+  - {fileID: 2087785541}

--- a/CapstoneProject/Assets/Scripts/Core/Entity/Characters/Playable_Character/Player.cs
+++ b/CapstoneProject/Assets/Scripts/Core/Entity/Characters/Playable_Character/Player.cs
@@ -127,40 +127,45 @@ namespace Core.Entity
 
             PlayerSaveData data = SaveSystem.LoadPlayer();
 
-            if (data != null)
-            {
-                Vector3 position;
+            string scene = SceneManager.GetActiveScene().name;
+            
 
-                Debug.Log("The scene the player was in was" + data.playerScene);
-                CoinComponent.ChangeCoins(data.playerCoins);
-                KeyItemComponent.ChangeKeys(data.playerKeys);
-                HealthComponent.ChangeHealth(data.playerHealth);
+                if (data != null && scene == data.playerScene)
+                
+                {
+               
+                    Vector3 position;
 
-                PlayerAbility abilityOne = deserializeAbility(data.playerAbilityOne);
-                PlayerAbility abilityTwo = deserializeAbility(data.playerAbilityTwo);
+                 //   Debug.Log("The scene the player was in was" + data.playerScene);
+                    CoinComponent.ChangeCoins(data.playerCoins);
+                    KeyItemComponent.ChangeKeys(data.playerKeys);
+                    HealthComponent.ChangeHealth(data.playerHealth);
+
+                    PlayerAbility abilityOne = deserializeAbility(data.playerAbilityOne);
+                    PlayerAbility abilityTwo = deserializeAbility(data.playerAbilityTwo);
 
 
 
-                AbilityComponent.SetupPlayerAbility(abilityOne, 0);
-                AbilityComponent.SetupPlayerAbility(abilityTwo, 1);
-                deserializeLearnedAbility(data.playerUnlockedAbilities[0], AbilityComponent.HealthRegenAbility);
-                deserializeLearnedAbility(data.playerUnlockedAbilities[1], AbilityComponent.ShieldAbility);
-                deserializeLearnedAbility(data.playerUnlockedAbilities[2], AbilityComponent.ProjectileShootingAbility);
-                deserializeLearnedAbility(data.playerUnlockedAbilities[3], AbilityComponent.BowShootingAbility);
-                deserializeLearnedAbility(data.playerUnlockedAbilities[4], AbilityComponent.LightningStrikeAbility);
-                //AbilityComponent.ChangeAbilties(data.playerAbilityOne, data.playerAbilityTwo);
-                Debug.Log(data.playerPosition[0]);
+                    AbilityComponent.SetupPlayerAbility(abilityOne, 0);
+                    AbilityComponent.SetupPlayerAbility(abilityTwo, 1);
+                    deserializeLearnedAbility(data.playerUnlockedAbilities[0], AbilityComponent.HealthRegenAbility);
+                    deserializeLearnedAbility(data.playerUnlockedAbilities[1], AbilityComponent.ShieldAbility);
+                    deserializeLearnedAbility(data.playerUnlockedAbilities[2], AbilityComponent.ProjectileShootingAbility);
+                    deserializeLearnedAbility(data.playerUnlockedAbilities[3], AbilityComponent.BowShootingAbility);
+                    deserializeLearnedAbility(data.playerUnlockedAbilities[4], AbilityComponent.LightningStrikeAbility);
+                    //AbilityComponent.ChangeAbilties(data.playerAbilityOne, data.playerAbilityTwo);
+                    Debug.Log(data.playerPosition[0]);
 
-                position.x = data.playerPosition[0];
-                position.y = data.playerPosition[1];
-                position.z = data.playerPosition[2];
-                transform.position = position;
-                return true;
-
-            }
+                    position.x = data.playerPosition[0];
+                    position.y = data.playerPosition[1];
+                    position.z = data.playerPosition[2];
+                    transform.position = position;
+                    return true;
+                }
+            
             else
             {
-                Debug.Log("Player Load attempted but no save data was found.");
+                Debug.Log("Player Load attempted but no save data was found, or scene loaded's name was identical to the scene saved.");
                 return false;
             }
 


### PR DESCRIPTION
the scene is included since the level triggering object was added. addionally, loading will now check the scene the player is in and compare it to the scene the player saved in, if they do not match the player won't load and a new save will be made on the spot